### PR TITLE
Correct SNAPSHOT spelling in build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,7 +2,7 @@ bundlename: esapi.extension
 filename: esapi-extension
 name: esapi
 bundleversion: 2.2.3.1-
-appendix: -SNAPHOT
+appendix: -SNAPSHOT
 id: 37C61C0A-5D7E-4256-8572639BE0CF5838
 label: ESAPI extension
 description: Extension for ESAPI functions 


### PR DESCRIPTION
The last two snapshots show up in Lucee admin with the format  `2.2.3.1-1-SNAPHOT`

The extra -1 is inconsistent with prior version numbering but that doesn't make it wrong; `SNAPHOT` should definitely be `SNAPSHOT` though.

https://luceeserver.atlassian.net/browse/LDEV-3876