### PR TITLE
Added a fix: cfoutput/writeoutput encodefor to support value empty string/none for LDEV-4009

### DIFF
--- a/source/java/src/org/lucee/extension/esapi/functions/ESAPIEncode.java
+++ b/source/java/src/org/lucee/extension/esapi/functions/ESAPIEncode.java
@@ -51,6 +51,7 @@ public class ESAPIEncode extends FunctionSupport {
 	public static final short ENC_XML = 12;
 	public static final short ENC_XML_ATTR = 13;
 	public static final short ENC_XPATH = 14;
+	public static final short ENC_NONE = 15;
 
 	public static String encode(String item, short encFor, boolean canonicalize) throws PageException {
 		return encode(item, encFor, canonicalize, null);
@@ -76,6 +77,8 @@ public class ESAPIEncode extends FunctionSupport {
 				return encoder.encodeForJavaScript(item);
 			case ENC_LDAP:
 				return encoder.encodeForLDAP(item);
+			case ENC_NONE:
+				return item;
 			case ENC_URL:
 				return encoder.encodeForURL(item);
 			case ENC_VB_SCRIPT:
@@ -146,6 +149,7 @@ public class ESAPIEncode extends FunctionSupport {
 		else if ("java script".equals(strEncodeFor)) return ENC_JAVA_SCRIPT;
 		else if ("java-script".equals(strEncodeFor)) return ENC_JAVA_SCRIPT;
 		else if ("ldap".equals(strEncodeFor)) return ENC_LDAP;
+		else if("".equals(strEncodeFor) || "none".equals(strEncodeFor)) return ENC_NONE;
 		// else if("".equals(strEncodeFor)) encFor=ENC_OS;
 		else if ("sql".equals(strEncodeFor)) return ENC_SQL;
 		else if ("url".equals(strEncodeFor)) return ENC_URL;

--- a/tests/LDEV4009.cfc
+++ b/tests/LDEV4009.cfc
@@ -10,6 +10,10 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="esapi"{
 				expect(trim(testfunc_writeoutput(""))).toBe("brad <br> wood");
 			});
 
+			it( title="writeoutput() with encodefor = html", body=function( currentSpec ) {
+				expect(trim(testfunc_writeoutput("html"))).toBe("brad &lt;br&gt; wood");
+			});
+
 			it( title="cfoutput with encodefor = none", body=function( currentSpec ) {
 				expect(trim(testfunc_cfoutput("none"))).toBe("brad <br> wood");
 			});
@@ -17,6 +21,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="esapi"{
 			it( title="cfoutput with encodefor = empty string", body=function( currentSpec ) {
 				expect(trim(testfunc_cfoutput(""))).toBe("brad <br> wood");
 			});
+
+			it( title="cfoutput with encodefor = html", body=function( currentSpec ) {
+				expect(trim(testfunc_cfoutput("html"))).toBe("brad &lt;br&gt; wood");
+			});
+			
 		});
 	}
 	

--- a/tests/LDEV4009.cfc
+++ b/tests/LDEV4009.cfc
@@ -1,0 +1,54 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="esapi"{
+	
+	function run( testResults, testBox ) {
+		describe("Testcase for LDEV-4009", function() {
+			it( title="writeoutput() with encodefor = none", body=function( currentSpec ) {
+				expect(trim(testfunc_writeoutput("none"))).toBe("brad <br> wood"); 
+			});
+			
+			it( title="writeoutput() with encodefor = empty string", body=function( currentSpec ) {
+				expect(trim(testfunc_writeoutput(""))).toBe("brad <br> wood");
+			});
+
+			it( title="cfoutput with encodefor = none", body=function( currentSpec ) {
+				expect(trim(testfunc_cfoutput("none"))).toBe("brad <br> wood");
+			});
+			
+			it( title="cfoutput with encodefor = empty string", body=function( currentSpec ) {
+				expect(trim(testfunc_cfoutput(""))).toBe("brad <br> wood");
+			});
+		});
+	}
+	
+	private function testfunc_writeoutput(required string encodefor) {
+		cfsavecontent(variable="result") {
+			try {
+				var name = "brad <br> wood" ;
+				writeoutput(name,arguments.encodefor);
+			}
+			catch(any e) {
+				writeoutput(e.message);
+			}
+		}
+		return result;
+	}
+
+	```
+	<cffunction name="testfunc_cfoutput" access="private">
+		<cfargument name="encodefor" type="string" required>
+		<cfsavecontent variable="result">
+			<cftry>
+				<cfset var name = "brad <br> wood">
+				<cfoutput encodeFor="#arguments.encodeFor#">
+					#name#
+				</cfoutput>
+				<cfcatch>
+					<cfoutput>#cfcatch.message#</cfoutput>
+				</cfcatch>
+			</cftry>
+		</cfsavecontent>
+		<cfreturn result>
+	</cffunction>
+
+	```
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4009